### PR TITLE
Add optional registered channel checks

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -4,6 +4,7 @@ require 'cinch/plugins/identify'
 require 'cinch/plugins/basic_ctcp'
 require 'json'
 require_relative 'stats.rb'
+require_relative 'reg_check.rb'
 
 cinch = Cinch::Bot.new do
   settings = JSON.load(open('settings.json','r'))
@@ -21,6 +22,7 @@ cinch = Cinch::Bot.new do
     config.plugins.prefix = '!'
     config.plugins.plugins = [
         Stats,
+        RegCheck,
         Cinch::Plugins::Identify,
         Cinch::Plugins::BasicCTCP
     ]
@@ -32,6 +34,10 @@ cinch = Cinch::Bot.new do
     config.plugins.options[Cinch::Plugins::BasicCTCP][:reply] = {
         :version  => 'StatsBot, an IRC statistics bot by /u/flotwig.',
         :source   => 'https://github.com/flotwig/StatsBot'
+    }
+    config.plugins.options[RegCheck] = {
+        :check => settings['check_registered'],
+        :mode => settings['registered_mode']
     }
   end
 end

--- a/reg_check.rb
+++ b/reg_check.rb
@@ -1,0 +1,20 @@
+require 'cinch'
+class RegCheck
+  include Cinch::Plugin
+  listen_to :join, :method => :join
+  listen_to :mode_change, :method => :mode_change
+
+  def join(msg)
+    if config[:check] && (msg.user.nick == bot.nick) && !msg.channel.modes[config[:mode]]
+      msg.channel.part('I do not stay in unregistered channels.')
+    end
+  end
+
+  def mode_change(msg, modes)
+    modes.each do |direction, mode, _param|
+      if config[:check] && (direction != :add) && (mode == config[:mode])
+        msg.channel.part('I do not stay in unregistered channels.')
+      end
+    end
+  end
+end

--- a/settings.example.json
+++ b/settings.example.json
@@ -16,5 +16,7 @@
 		"nick": "StatsBot",
 		"ident": "statsbot",
 		"realname": "StatsBot"
-	}
+	},
+	"check_registered": true,
+	"registered_mode": "r"
 }


### PR DESCRIPTION
This adds a check for the `r` channel mode so the bot will automatically part unregistered channels.